### PR TITLE
Fix error during writing to CAN

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-smartweb (1.3.3) stable; urgency=medium
+
+  * Fix error during writing to CAN
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 22 Jun 2023 18:54:41 +0500
+
 wb-mqtt-smartweb (1.3.2) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-4. No functional changes

--- a/src/CanPort.cpp
+++ b/src/CanPort.cpp
@@ -1,15 +1,15 @@
 #include "CanPort.h"
 
 #include <algorithm>
+#include <condition_variable>
 #include <net/if.h>
+#include <queue>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <vector>
-#include <queue>
-#include <condition_variable>
 #include <wblib/utils.h>
 
 #include "log.h"
@@ -19,7 +19,7 @@
 namespace
 {
     const auto READ_TIMEOUT_MS = std::chrono::milliseconds(1000); // 1 sec for messages waiting
-    const auto WRITE_TIMEOUT = std::chrono::seconds(5); // 5 sec wait for port ready to write
+    const auto WRITE_TIMEOUT = std::chrono::seconds(5);           // 5 sec wait for port ready to write
 
     template<class TDuration> void setTimeval(timeval& tv, TDuration timeout)
     {
@@ -128,7 +128,6 @@ namespace
                     }
                 }
             });
-
 
             DispatchThread = std::thread([&]() {
                 WBMQTT::SetThreadName("CAN dispatch");

--- a/src/CanPort.cpp
+++ b/src/CanPort.cpp
@@ -8,6 +8,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <vector>
+#include <queue>
+#include <condition_variable>
 #include <wblib/utils.h>
 
 #include "log.h"
@@ -17,14 +19,31 @@
 namespace
 {
     const auto READ_TIMEOUT_MS = std::chrono::milliseconds(1000); // 1 sec for messages waiting
+    const auto WRITE_TIMEOUT = std::chrono::seconds(5); // 5 sec wait for port ready to write
+
+    template<class TDuration> void setTimeval(timeval& tv, TDuration timeout)
+    {
+        tv.tv_sec = std::chrono::ceil<std::chrono::seconds>(timeout).count();
+        tv.tv_usec = (std::chrono::ceil<std::chrono::microseconds>(timeout).count() % 1000) * 1000;
+    }
 
     class TCanPort: public CAN::IPort
     {
         int Socket;
-        std::thread Thread;
+        std::thread ReadThread;
         std::atomic_bool Enabled;
         std::mutex HandlersMutex;
+        std::mutex WriteMutex;
         std::vector<CAN::IFrameHandler*> Handlers;
+
+        std::mutex WriteConfirmMutex;
+        std::condition_variable WriteConfirmCv;
+        bool Confirmed = false;
+
+        std::thread DispatchThread;
+        std::mutex CanDispatchMutex;
+        std::condition_variable CanDispatchCv;
+        std::queue<CAN::TFrame> CanFrames;
 
     public:
         TCanPort(const std::string& ifname)
@@ -35,6 +54,10 @@ namespace
             if ((Socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
                 throw std::runtime_error("Error while opening CAN socket");
             }
+
+            int enable = 1;
+            setsockopt(Socket, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &enable, sizeof(enable));
+            setsockopt(Socket, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &enable, sizeof(enable));
 
             strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
             ifr.ifr_name[IFNAMSIZ - 1] = '\0';
@@ -55,7 +78,7 @@ namespace
 
             Enabled.store(true);
 
-            Thread = std::thread([&]() {
+            ReadThread = std::thread([&]() {
                 WBMQTT::SetThreadName("CAN listener");
                 while (Enabled.load()) {
                     timeval tv;
@@ -70,18 +93,30 @@ namespace
                         exit(1);
                     }
                     if (r > 0) {
-                        CAN::TFrame frame{0};
-                        auto nread = read(Socket, &frame, sizeof(CAN::TFrame));
+                        can_frame frame{0};
+                        frame.can_dlc = 1;
+                        uint8_t ctrlmsg[CMSG_SPACE(sizeof(struct timeval)) + CMSG_SPACE(sizeof(__u32))];
+                        iovec iov{0};
+                        iov.iov_base = &frame;
+                        msghdr msg{0};
+                        msg.msg_iov = &iov;
+                        msg.msg_iovlen = 1;
+                        msg.msg_control = &ctrlmsg;
+
+                        msg.msg_iov[0].iov_len = sizeof(frame);
+                        msg.msg_controllen = sizeof(ctrlmsg);
+                        msg.msg_flags = 0;
+
+                        auto nread = recvmsg(Socket, &msg, 0);
                         if (nread == sizeof(CAN::TFrame)) {
-                            std::unique_lock<std::mutex> lk(HandlersMutex);
-                            for (auto& handler: Handlers) {
-                                try {
-                                    if (handler->Handle(frame)) {
-                                        break;
-                                    }
-                                } catch (const std::exception& e) {
-                                    LOG(WBMQTT::Error) << e.what();
-                                }
+                            if (msg.msg_flags & MSG_CONFIRM) {
+                                std::unique_lock<std::mutex> waitLock(WriteConfirmMutex);
+                                Confirmed = true;
+                                WriteConfirmCv.notify_all();
+                            } else {
+                                std::unique_lock<std::mutex> waitLock(CanDispatchMutex);
+                                CanFrames.push(frame);
+                                CanDispatchCv.notify_all();
                             }
                         } else {
                             if (nread < 0) {
@@ -93,13 +128,45 @@ namespace
                     }
                 }
             });
+
+
+            DispatchThread = std::thread([&]() {
+                WBMQTT::SetThreadName("CAN dispatch");
+
+                CAN::TFrame frame;
+                while (Enabled.load()) {
+                    {
+                        std::unique_lock<std::mutex> waitLock(CanDispatchMutex);
+                        if (CanFrames.empty()) {
+                            if (std::cv_status::timeout == CanDispatchCv.wait_for(waitLock, READ_TIMEOUT_MS)) {
+                                continue;
+                            }
+                        }
+                        frame = CanFrames.front();
+                        CanFrames.pop();
+                    }
+                    std::unique_lock<std::mutex> lk(HandlersMutex);
+                    for (auto& handler: Handlers) {
+                        try {
+                            if (handler->Handle(frame)) {
+                                break;
+                            }
+                        } catch (const std::exception& e) {
+                            LOG(WBMQTT::Error) << e.what();
+                        }
+                    }
+                }
+            });
         }
 
         ~TCanPort()
         {
             Enabled.store(false);
-            if (Thread.joinable()) {
-                Thread.join();
+            if (ReadThread.joinable()) {
+                ReadThread.join();
+            }
+            if (DispatchThread.joinable()) {
+                DispatchThread.join();
             }
             close(Socket);
         }
@@ -118,10 +185,23 @@ namespace
 
         void Send(const CAN::TFrame& frame)
         {
+            std::unique_lock<std::mutex> lk(WriteMutex);
+            {
+                std::unique_lock<std::mutex> waitLock(WriteConfirmMutex);
+                Confirmed = false;
+            }
+
             auto nbytes = write(Socket, &frame, CAN_MTU);
 
             if (nbytes < static_cast<int>(CAN_MTU)) {
                 throw std::runtime_error(std::string("CAN write error: ") + strerror(errno));
+            }
+            std::unique_lock<std::mutex> waitLock(WriteConfirmMutex);
+            if (Confirmed) {
+                return;
+            }
+            if (std::cv_status::timeout == WriteConfirmCv.wait_for(waitLock, WRITE_TIMEOUT)) {
+                throw std::runtime_error("CAN write timeout");
             }
         }
     };

--- a/src/MqttToSmartWebGateway.cpp
+++ b/src/MqttToSmartWebGateway.cpp
@@ -15,9 +15,9 @@ namespace
     const auto KEEP_ALIVE_INTERVAL_S = TTimeIntervalS(10); // if nothing else to do - each 10 seconds send I_AM_HERE
     const auto CONNECTION_TIMEOUT_MIN =
         TTimeIntervalMin(10); // after 10 minutes without any messages connection is considered lost
-    const auto SEND_MESSAGES_TIME_M = TTimeIntervalMin(10);       // send value during 10 minutes
+    const auto SEND_MESSAGES_TIME_M = TTimeIntervalMin(10);        // send value during 10 minutes
     const auto SEND_MESSAGES_INTERVAL_MS = TTimeIntervalMs(30000); // interval between messages
-    const auto READ_TIMEOUT_MS = TTimeIntervalMs(1000);           // 1 sec for messages waiting
+    const auto READ_TIMEOUT_MS = TTimeIntervalMs(1000);            // 1 sec for messages waiting
 
     TTimePoint now()
     {
@@ -78,7 +78,7 @@ string TMqttChannel::to_string() const
 
 void TChannelState::postpone_send()
 {
-    LastSendTimePoint = now(); 
+    LastSendTimePoint = now();
     SendTimePoint = LastSendTimePoint + SEND_MESSAGES_INTERVAL_MS;
 }
 
@@ -344,9 +344,9 @@ void TMqttToSmartWebGateway::TaskFn()
 
         if (itDeviceChannel == DriverState.ParameterMapping.end()) {
             DebugMqttToSw.Log() << "[" << (int)DriverState.ProgramId
-                               << "] unmapped parameter: type: " << (int)parameter_data.program_type
-                               << ", id: " << (int)parameter_data.parameter_id
-                               << ", index: " << (int)parameter_data.indexed_parameter.index;
+                                << "] unmapped parameter: type: " << (int)parameter_data.program_type
+                                << ", id: " << (int)parameter_data.parameter_id
+                                << ", index: " << (int)parameter_data.indexed_parameter.index;
         } else {
             DebugMqttToSw.Log() << "[" << (int)DriverState.ProgramId
                                 << "] get parameter: type: " << (int)parameter_data.program_type
@@ -421,9 +421,9 @@ void TMqttToSmartWebGateway::TaskFn()
                 continue; // weird
             }
 
-            auto lastUpdate = DriverState.MqttChannelsTiming
-                                         .at(TMqttChannel::to_string(channel.device, channel.control))
-                                         .get_last_update_timepoint();
+            auto lastUpdate =
+                DriverState.MqttChannelsTiming.at(TMqttChannel::to_string(channel.device, channel.control))
+                    .get_last_update_timepoint();
             if (lastUpdate <= channel.LastSendTimePoint) { // no channel updates
                 if (channel.SendTimePoint > now()) {
                     continue; // too soon

--- a/src/MqttToSmartWebGateway.cpp
+++ b/src/MqttToSmartWebGateway.cpp
@@ -16,7 +16,7 @@ namespace
     const auto CONNECTION_TIMEOUT_MIN =
         TTimeIntervalMin(10); // after 10 minutes without any messages connection is considered lost
     const auto SEND_MESSAGES_TIME_M = TTimeIntervalMin(10);       // send value during 10 minutes
-    const auto SEND_MESSAGES_INTERVAL_MS = TTimeIntervalMs(1000); // interval between messages
+    const auto SEND_MESSAGES_INTERVAL_MS = TTimeIntervalMs(30000); // interval between messages
     const auto READ_TIMEOUT_MS = TTimeIntervalMs(1000);           // 1 sec for messages waiting
 
     TTimePoint now()
@@ -78,7 +78,8 @@ string TMqttChannel::to_string() const
 
 void TChannelState::postpone_send()
 {
-    SendTimePoint = now() + SEND_MESSAGES_INTERVAL_MS;
+    LastSendTimePoint = now(); 
+    SendTimePoint = LastSendTimePoint + SEND_MESSAGES_INTERVAL_MS;
 }
 
 void TChannelState::postpone_send_end()
@@ -120,6 +121,11 @@ bool TMqttChannelTiming::is_timed_out() const
 
     unique_lock<mutex> lock(LastUpdateTimePointMutex);
     return (now() - LastUpdateTimePoint) > ValueTimeoutMin;
+}
+
+TTimePoint TMqttChannelTiming::get_last_update_timepoint() const
+{
+    return LastUpdateTimePoint;
 }
 
 bool TMqttToSmartWebGateway::FilterIsSet = false;
@@ -337,7 +343,7 @@ void TMqttToSmartWebGateway::TaskFn()
         int16_t value = SmartWeb::SENSOR_UNDEFINED;
 
         if (itDeviceChannel == DriverState.ParameterMapping.end()) {
-            WarnMqttToSw.Log() << "[" << (int)DriverState.ProgramId
+            DebugMqttToSw.Log() << "[" << (int)DriverState.ProgramId
                                << "] unmapped parameter: type: " << (int)parameter_data.program_type
                                << ", id: " << (int)parameter_data.parameter_id
                                << ", index: " << (int)parameter_data.indexed_parameter.index;
@@ -411,12 +417,17 @@ void TMqttToSmartWebGateway::TaskFn()
                 continue; // too late
             }
 
-            if (channel.SendTimePoint > now()) {
-                continue; // too soon
-            }
-
             if (channel.device.empty() || channel.control.empty()) {
                 continue; // weird
+            }
+
+            auto lastUpdate = DriverState.MqttChannelsTiming
+                                         .at(TMqttChannel::to_string(channel.device, channel.control))
+                                         .get_last_update_timepoint();
+            if (lastUpdate <= channel.LastSendTimePoint) { // no channel updates
+                if (channel.SendTimePoint > now()) {
+                    continue; // too soon
+                }
             }
 
             auto value = read_mqtt_value(channel.device, channel.control);

--- a/src/MqttToSmartWebGateway.h
+++ b/src/MqttToSmartWebGateway.h
@@ -41,6 +41,7 @@ struct TChannelState
 {
     TTimePoint SendTimePoint;    // next send timepoint
     TTimePoint SendEndTimePoint; // when to stop sending messages
+    TTimePoint LastSendTimePoint; // last send timepoint
 
     void postpone_send();
     void postpone_send_end();
@@ -68,6 +69,7 @@ public:
 
     void refresh_last_update_timepoint();
     bool is_timed_out() const;
+    TTimePoint get_last_update_timepoint() const;
 };
 
 struct TMqttToSmartWebConfig

--- a/src/MqttToSmartWebGateway.h
+++ b/src/MqttToSmartWebGateway.h
@@ -39,8 +39,8 @@ struct TMqttChannel
 
 struct TChannelState
 {
-    TTimePoint SendTimePoint;    // next send timepoint
-    TTimePoint SendEndTimePoint; // when to stop sending messages
+    TTimePoint SendTimePoint;     // next send timepoint
+    TTimePoint SendEndTimePoint;  // when to stop sending messages
     TTimePoint LastSendTimePoint; // last send timepoint
 
     void postpone_send();

--- a/src/SmartWebToMqttGateway.cpp
+++ b/src/SmartWebToMqttGateway.cpp
@@ -53,7 +53,10 @@ std::string TSensorCodec::Decode(const uint8_t* buf) const
 {
     int16_t v;
     memcpy(&v, buf, 2);
-    if (v == SENSOR_SHORT_VALUE || v == SENSOR_OPEN_VALUE || v == SENSOR_UNDEFINED) {
+    if (v == SENSOR_UNDEFINED) {
+        throw std::runtime_error("sensor is in undefined state");
+    }
+    if (v == SENSOR_SHORT_VALUE || v == SENSOR_OPEN_VALUE) {
         throw std::runtime_error("sensor error " + std::to_string(v));
     }
     return WBMQTT::FormatFloat(v / 10.0);

--- a/src/SmartWebToMqttGateway.cpp
+++ b/src/SmartWebToMqttGateway.cpp
@@ -136,33 +136,39 @@ std::string TOutputCodec::GetName() const
 TSmartWebToMqttGateway::TSmartWebToMqttGateway(const TSmartWebToMqttConfig& config,
                                                std::shared_ptr<CAN::IPort> canPort,
                                                WBMQTT::PDeviceDriver driver)
-    : CanPort(canPort),
-      Config(config),
+    : Config(config),
       Driver(driver),
       RequestIndex(0),
       Scheduler(MakeSimpleThreadedScheduler("SW to MQTT"))
 {
-    EventHandler = Driver->On<WBMQTT::TControlOnValueEvent>([this](const WBMQTT::TControlOnValueEvent& event) {
+    EventHandler = Driver->On<WBMQTT::TControlOnValueEvent>([this, canPort](const WBMQTT::TControlOnValueEvent& event) {
         try {
             auto param = event.Control->GetUserData().As<TSmartWebParameterControl>();
             auto frame = MakeSetParameterValueRequest(param, event.RawValue);
-            CanPort->Send(frame);
+            canPort->Send(frame);
             print_frame(DebugSwToMqtt, frame, "Set value request");
         } catch (const std::exception& e) {
             ErrorSwToMqtt.Log() << "Set value request: " << e.what();
         }
     });
+
     Scheduler->AddTask(MakePeriodicTask(
         config.PollInterval,
-        [this]() { this->HandleMapping(); },
+        [this, canPort]() { this->HandleMapping(*canPort); },
         "SmartWeb->MQTT task"));
-    CanPort->AddHandler(this);
+
+    CanReader = std::make_unique<TThreadedCanReader>(
+        "SmartWeb->MQTT reader",
+        canPort,
+        100,
+        [this](const CAN::TFrame& frame) { return AcceptFrame(frame); },
+        [this](const CAN::TFrame& frame) { HandleFrame(frame); });
 }
 
 TSmartWebToMqttGateway::~TSmartWebToMqttGateway()
 {
     Scheduler.reset();
-    CanPort->RemoveHandler(this);
+    CanReader.reset();
     Driver->RemoveEventHandler(EventHandler);
     auto tx = Driver->BeginTx();
     for (const auto& d: DeviceIds) {
@@ -170,7 +176,24 @@ TSmartWebToMqttGateway::~TSmartWebToMqttGateway()
     }
 }
 
-bool TSmartWebToMqttGateway::Handle(const CAN::TFrame& frame)
+void TSmartWebToMqttGateway::HandleFrame(const CAN::TFrame& frame)
+{
+    SmartWeb::TCanHeader* header = (SmartWeb::TCanHeader*)&frame.can_id;
+    if (header->rec.program_type == SmartWeb::PT_PROGRAM &&
+        header->rec.function_id == SmartWeb::Program::Function::I_AM_PROGRAM)
+    {
+        AddProgram(frame);
+        return;
+    }
+
+    if (header->rec.program_type == SmartWeb::PT_REMOTE_CONTROL &&
+        header->rec.function_id == SmartWeb::RemoteControl::Function::GET_PARAMETER_VALUE)
+    {
+        HandleGetValueResponse(frame);
+    }
+}
+
+bool TSmartWebToMqttGateway::AcceptFrame(const CAN::TFrame& frame) const
 {
     if (!(frame.can_id & CAN_EFF_FLAG)) {
         return false;
@@ -184,21 +207,19 @@ bool TSmartWebToMqttGateway::Handle(const CAN::TFrame& frame)
     if (header->rec.program_type == SmartWeb::PT_PROGRAM &&
         header->rec.function_id == SmartWeb::Program::Function::I_AM_PROGRAM)
     {
-        AddProgram(frame);
         return true;
     }
 
     if (header->rec.program_type == SmartWeb::PT_REMOTE_CONTROL &&
         header->rec.function_id == SmartWeb::RemoteControl::Function::GET_PARAMETER_VALUE)
     {
-        HandleGetValueResponse(frame);
         return true;
     }
 
     return false;
 }
 
-void TSmartWebToMqttGateway::HandleMapping()
+void TSmartWebToMqttGateway::HandleMapping(CAN::IPort& canPort)
 {
     CAN::TFrame frame;
     {
@@ -212,7 +233,7 @@ void TSmartWebToMqttGateway::HandleMapping()
         frame = Requests[RequestIndex];
     }
     try {
-        CanPort->Send(frame);
+        canPort.Send(frame);
         print_frame(DebugSwToMqtt, frame, "Send request");
     } catch (const std::exception& e) {
         print_frame(ErrorSwToMqtt, frame, std::string("Send request: ") + e.what());

--- a/src/ThreadedCanReader.cpp
+++ b/src/ThreadedCanReader.cpp
@@ -1,0 +1,68 @@
+#include "ThreadedCanReader.h"
+
+#include <cstring>
+#include <wblib/utils.h>
+
+namespace
+{
+    const auto READ_TIMEOUT = std::chrono::milliseconds(1000);
+}
+
+TThreadedCanReader::TThreadedCanReader(const std::string& threadName,
+                                       std::shared_ptr<CAN::IPort> canPort,
+                                       size_t framesQueueMaxLength,
+                                       std::function<bool(const CAN::TFrame& frame)> acceptFrame,
+                                       std::function<void(const CAN::TFrame& frame)> handleFrame)
+    : CanPort(canPort),
+      FramesQueueMaxLength(framesQueueMaxLength),
+      AcceptFrame(acceptFrame)
+{
+    Enabled.store(true);
+    CanPort->AddHandler(this);
+
+    Thread = std::thread([this, threadName, handleFrame]() {
+        WBMQTT::SetThreadName(threadName);
+        CAN::TFrame frame;
+        while (Enabled.load()) {
+            memset(&frame, 0, sizeof(CAN::TFrame));
+            if (Get(frame)) {
+                handleFrame(frame);
+            }
+        }
+    });
+}
+
+TThreadedCanReader::~TThreadedCanReader()
+{
+    CanPort->RemoveHandler(this);
+    Enabled.store(false);
+    if (Thread.joinable()) {
+        Thread.join();
+    }
+}
+
+bool TThreadedCanReader::Handle(const CAN::TFrame& frame)
+{
+    if (!AcceptFrame(frame)) {
+        return false;
+    }
+    std::unique_lock<std::mutex> waitLock(Mutex);
+    if (Frames.size() < FramesQueueMaxLength) {
+        Frames.push(frame);
+        Cv.notify_all();
+    }
+    return true;
+}
+
+bool TThreadedCanReader::Get(CAN::TFrame& frame)
+{
+    std::unique_lock<std::mutex> waitLock(Mutex);
+    if (Frames.empty()) {
+        if (std::cv_status::timeout == Cv.wait_for(waitLock, READ_TIMEOUT)) {
+            return false;
+        }
+    }
+    frame = Frames.front();
+    Frames.pop();
+    return true;
+}

--- a/src/ThreadedCanReader.h
+++ b/src/ThreadedCanReader.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+#include "CanPort.h"
+
+class TThreadedCanReader: public CAN::IFrameHandler
+{
+    std::shared_ptr<CAN::IPort> CanPort;
+
+    std::mutex Mutex;
+    std::condition_variable Cv;
+    std::queue<CAN::TFrame> Frames;
+    size_t FramesQueueMaxLength;
+
+    std::thread Thread;
+    std::atomic_bool Enabled;
+
+    std::function<bool(const CAN::TFrame& frame)> AcceptFrame;
+
+    bool Handle(const CAN::TFrame& frame);
+    bool Get(CAN::TFrame& frame);
+
+public:
+    TThreadedCanReader(const std::string& threadName,
+                       std::shared_ptr<CAN::IPort> canPort,
+                       size_t framesQueueMaxLength,
+                       std::function<bool(const CAN::TFrame& frame)> acceptFrame,
+                       std::function<void(const CAN::TFrame& frame)> handleFrame);
+    ~TThreadedCanReader();
+};

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -359,12 +359,12 @@ void LoadConfig(TConfig& config,
     Json::Value classSchema = WBMQTT::JSON::Parse(classSchemaFileName);
     LoadSmartWebToMqttConfig(config.SmartWebToMqtt,
                              configJson,
-                             pathToDeviceClassDirectory,
+                             pathToBuiltInDeviceClassDirectory,
                              classSchema,
                              TDeviceClassSource::BUILTIN);
     LoadSmartWebToMqttConfig(config.SmartWebToMqtt,
                              configJson,
-                             pathToBuiltInDeviceClassDirectory,
+                             pathToDeviceClassDirectory,
                              classSchema,
                              TDeviceClassSource::USER);
 }

--- a/test/config.test.cpp
+++ b/test/config.test.cpp
@@ -94,7 +94,7 @@ TEST_F(TLoadConfigTest, SmartWebToMqttConfigInputs)
     auto config = GetTestConfig();
     const auto smartWebClass = config->Classes.begin()->second;
 
-    EXPECT_EQ(7, smartWebClass->Inputs.size());
+    EXPECT_EQ(6, smartWebClass->Inputs.size());
     auto input = smartWebClass->Inputs.at(2);
 
     TestClassParameterSample sample = {.id = 2,
@@ -171,7 +171,7 @@ TEST_F(TLoadConfigTest, LoadConfig)
     auto roomDeviceClass = config.SmartWebToMqtt.Classes[5];
     ASSERT_NE(nullptr, roomDeviceClass);
     EXPECT_EQ("ROOM_DEVICE", roomDeviceClass->Name);
-    EXPECT_EQ(7, roomDeviceClass->Inputs.size());
+    EXPECT_EQ(6, roomDeviceClass->Inputs.size());
     EXPECT_EQ(7, roomDeviceClass->Outputs.size());
     EXPECT_EQ(34, roomDeviceClass->Parameters.size());
 

--- a/test/config_test_data/classes/ROOM_DEVICE.json
+++ b/test/config_test_data/classes/ROOM_DEVICE.json
@@ -6,7 +6,6 @@
 	"implements": ["PROGRAM"],
 	"inputs": {
 		"roomT":	{"id":0, "type": "temperature"},
-		"rc21": 	{"id":1, "type": "rc21"},
 		"floorT": 	{"id":2, "type": "temperature"},
 		"wallT": 	{"id":3, "type": "temperature"},
 		"humidity":	{"id":4, "type": "humidity"},


### PR DESCRIPTION
* move unmapped parameter warning to debug
* add more verbose warning about sensors in undefined state
 * send outputs every 30 seconds and on change instead of sending every second
 * wait CAN write confirmation