### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test: $(TEST_DIR)/$(TEST_TARGET)
 		if [ $$? = 180 ]; then \
 			echo "*** VALGRIND DETECTED ERRORS ***" 1>& 2; \
 			exit 1; \
-		fi \
+		else exit 1; fi; \
 	else \
 		$(TEST_DIR)/$(TEST_TARGET); \
 	fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-smartweb (1.4.2) stable; urgency=medium
+
+  * Fix makefile, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 11 Dec 2023 15:00:06 +0400
+
 wb-mqtt-smartweb (1.4.1) stable; urgency=medium
 
   * Add arm64 build, no functional changes


### PR DESCRIPTION
Фейл запуска тестов игнорировался и `make test` всегда завершался успешно.