### PR TITLE
Remove obsolete outputs parameter from default config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
+               defaultAngryClangTidy: false,
                defaultStyleCheckDirs: 'src test'

--- a/config.json
+++ b/config.json
@@ -11,13 +11,6 @@
                     "sensor_index": 1
                 }
             ],
-            "outputs": [
-                {
-                    "channel": "wb-adc/R1",
-                    "value_timeout_min": 60,
-                    "output_index": 0
-                }
-            ],
             "parameters": [
                 {
                     "channel": "wb-adc/Vin",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-smartweb (1.4.4) stable; urgency=medium
+
+  * Remove obsolete outputs parameter from default config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 22 Feb 2024 18:06:23 +0500
+
 wb-mqtt-smartweb (1.4.3) stable; urgency=medium
 
   * Add "interface_name" to config

--- a/src/MqttToSmartWebGateway.cpp
+++ b/src/MqttToSmartWebGateway.cpp
@@ -190,7 +190,7 @@ bool TMqttToSmartWebGateway::IsForMe(const SmartWeb::TCanHeader& header, const T
     {
         SmartWeb::TMappingPoint mapping_point;
         memcpy(&mapping_point.raw, data, 2);
-        return mapping_point.hostID == DriverState.ProgramId;
+        return mapping_point.hostID == DriverState.ProgramId; // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
     }
 
     return false;

--- a/src/MqttToSmartWebGateway.cpp
+++ b/src/MqttToSmartWebGateway.cpp
@@ -190,7 +190,8 @@ bool TMqttToSmartWebGateway::IsForMe(const SmartWeb::TCanHeader& header, const T
     {
         SmartWeb::TMappingPoint mapping_point;
         memcpy(&mapping_point.raw, data, 2);
-        return mapping_point.hostID == DriverState.ProgramId; // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
+        return mapping_point.hostID ==
+               DriverState.ProgramId; // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
     }
 
     return false;

--- a/src/SmartWebToMqttGateway.h
+++ b/src/SmartWebToMqttGateway.h
@@ -69,7 +69,7 @@ public:
         std::vector<uint8_t> res;
         for (size_t i = 0; i < sizeof(Int); ++i) {
             res.push_back(v & 0xFF);
-            v >>= 8;
+            v >>= 8; // NOLINT(clang-diagnostic-shift-count-overflow)
         }
         return res;
     }

--- a/src/SmartWebToMqttGateway.h
+++ b/src/SmartWebToMqttGateway.h
@@ -103,7 +103,7 @@ public:
         std::vector<uint8_t> res;
         for (size_t i = 0; i < sizeof(Int); ++i) {
             res.push_back(v & 0xFF);
-            v >>= 8;
+            v >>= 8; // NOLINT(clang-diagnostic-shift-count-overflow)
         }
         return res;
     }

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -277,8 +277,8 @@ namespace
             }
         }
 
-        if (!configJson.isMember("parameters") && !configJson.isMember("sensors") && !configJson.isMember("outputs")) {
-            throw std::runtime_error("Malformed JSON config: no parameter, sensor or output in mapping");
+        if (!configJson.isMember("parameters") && !configJson.isMember("sensors")) {
+            throw std::runtime_error("Malformed JSON config: no parameter or sensor in mapping");
         }
         return res;
     }

--- a/test/config_test_data/test_config.json
+++ b/test/config_test_data/test_config.json
@@ -11,13 +11,6 @@
                     "sensor_index": 1
                 }
             ],
-            "outputs": [
-                {
-                    "channel": "wb-adc/R1",
-                    "value_timeout_min": 60,
-                    "output_index": 0
-                }
-            ],
             "parameters": [
                 {
                     "channel": "wb-adc/Vin",


### PR DESCRIPTION
outputs убрали в версии 1.0.0, а в дефолтном конфиге забыл убрать

От разработчиков SmartWeb
`
Тут немного по-другому. Сущность одна, датчики остаются датчиками. Просто для их передачи в кан шину используется функция controller.getOutputValue. Вы спросите, а как же функция remoteControl.getParameter(controller, sensorN) . Исторически так сложилось, что эта функция не используется в логике работы контроллеров смартвеб, а используется только для внешних систем мониторинга. В общем, нужно и то и другое чтобы работало, но не вижу причины для этого заводить ещё блок с "выходами"
`