### PR TITLE
Fix default config

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
             "sensors": [
                 {
                     "channel": "wb-adc/R1",
-                    "sensor_index": 1
+                    "sensor_index": 1,
+                    "value_timeout_min": -1
                 }
             ],
             "parameters": [
@@ -16,7 +17,8 @@
                     "channel": "wb-adc/Vin",
                     "parameter_id": 1,
                     "program_type": 11,
-                    "parameter_index": 0
+                    "parameter_index": 0,
+                    "value_timeout_min": -1
                 }
             ]
         }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-smartweb (1.4.6) stable; urgency=medium
+
+  * Fix default config (add value_timeout_min)
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 12 Jul 2024 00:30:00 +0400
+
 wb-mqtt-smartweb (1.4.5) stable; urgency=medium
 
   * Add json editor autocomplete for devices


### PR DESCRIPTION
С текущим дефолтным конфигом до первого его сохранения при переходе в UI получаем "The page has unsaved changes. Are you sure you want to leave?"

scope.file.content:
`{"debug":false,"poll_interval_ms":1000,"interface_name":"can0","controllers":[{"controller_id":204,"sensors":[{"channel":"wb-adc/R1","sensor_index":1}],"parameters":[{"channel":"wb-adc/Vin","parameter_id":1,"program_type":11,"parameter_index":0}]}]}`

content:
`{"poll_interval_ms":1000,"interface_name":"can0","controllers":[{"controller_id":204,"parameters":[{"channel":"wb-adc/Vin","parameter_id":1,"parameter_index":0,"program_type":11,"value_timeout_min":-1}],"sensors":[{"channel":"wb-adc/R1","sensor_index":1,"value_timeout_min":-1}]}],"debug":false}`