### PR TITLE
Add coverage report generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultAngryClangTidy: false,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '39'
+               defaultCoverageMin: '34'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultAngryClangTidy: false,
-               defaultStyleCheckDirs: 'src test'
+               defaultStyleCheckDirs: 'src test',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '39'

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 	CMAKE_BUILD_TYPE=Debug
 endif
 
-COMMON_SRCS := $(shell find $(SRC_DIRS) \( -name *.cpp -or -name *.c \) -and -not -name main.cpp)
+COMMON_SRCS := $(shell find $(SRC_DIRS) \( -name "*.cpp" -or -name "*.c" \) -and -not -name main.cpp)
 COMMON_OBJS := $(COMMON_SRCS:%=$(BUILD_DIR)/%.o)
 
 LDFLAGS = -lwbmqtt1 -lpthread
@@ -36,16 +36,23 @@ CFLAGS = -Wall -I$(SRC_DIR)
 ifeq ($(DEBUG),)
 	CXXFLAGS += -O2
 else
-	CXXFLAGS += -g -O0 -fprofile-arcs -ftest-coverage -ggdb
-	LDFLAGS += -lgcov
+	CXXFLAGS += -g -O0 --coverage -ggdb
+	LDFLAGS += --coverage
 endif
 
-
 TEST_DIR = test
-TEST_SRCS := $(shell find $(TEST_DIR) \( -name *.cpp -or -name *.c \) -and -not -name main.cpp)
+TEST_SRCS := $(shell find $(TEST_DIR) \( -name "*.cpp" -or -name "*.c" \) -and -not -name main.cpp)
 TEST_OBJS := $(TEST_SRCS:%=$(BUILD_DIR)/%.o)
 TEST_TARGET = test-app
 TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
+
+VALGRIND_FLAGS = --error-exitcode=180 -q
+
+COV_REPORT ?= $(BUILD_DIR)/cov.html
+GCOVR_FLAGS := --html $(COV_REPORT)
+ifneq ($(COV_FAIL_UNDER),)
+	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
+endif
 
 all: $(TARGET)
 
@@ -59,12 +66,9 @@ $(BUILD_DIR)/%.cpp.o: %.cpp
 	mkdir -p $(dir $@)
 	$(CXX) -c $(CXXFLAGS) -o $@ $^
 
-$(BUILD_DIR)/test/%.o: test/%.cpp
-	$(CXX) -c $(CXXFLAGS) -o $@ $^
-
 test: $(TEST_DIR)/$(TEST_TARGET)
 	if [ "$(shell arch)" != "armv7l" ] && [ "$(CROSS_COMPILE)" = "" ] || [ "$(CROSS_COMPILE)" = "x86_64-linux-gnu-" ]; then \
-		valgrind --error-exitcode=180 -q $(TEST_DIR)/$(TEST_TARGET) || \
+		valgrind $(VALGRIND_FLAGS) $(TEST_DIR)/$(TEST_TARGET) || \
 		if [ $$? = 180 ]; then \
 			echo "*** VALGRIND DETECTED ERRORS ***" 1>& 2; \
 			exit 1; \
@@ -72,6 +76,9 @@ test: $(TEST_DIR)/$(TEST_TARGET)
 	else \
 		$(TEST_DIR)/$(TEST_TARGET); \
 	fi
+ifneq ($(DEBUG),)
+	gcovr $(GCOVR_FLAGS) $(BUILD_DIR)/$(SRC_DIR) $(BUILD_DIR)/$(TEST_DIR)
+endif
 
 $(TEST_DIR)/$(TEST_TARGET): $(TEST_OBJS) $(COMMON_OBJS) $(BUILD_DIR)/test/main.cpp.o
 	$(CXX) -o $@ $^ $(LDFLAGS) $(TEST_LDFLAGS) -fno-lto

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := --html $(COV_REPORT)
+GCOVR_FLAGS := -s --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ TEST_LDFLAGS = -lgtest -lwbmqtt_test_utils
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
-COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := -s --html $(COV_REPORT)
+COV_REPORT ?= $(BUILD_DIR)/cov
+GCOVR_FLAGS := -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-smartweb (1.4.9) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-smartweb (1.4.8) stable; urgency=medium
 
   * More verbose log message

--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,11 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 10),
-               pkg-config,
+               gcovr:all,
+               libgtest-dev,
                libwbmqtt1-5-dev,
                libwbmqtt1-5-test-utils,
-               libgtest-dev
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-smartweb
 
 Package: wb-mqtt-smartweb

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,18 @@
 #!/usr/bin/make -f
+
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open build/debug/cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=39 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-10-1 kello 4 02 11" src="https://github.com/user-attachments/assets/dc72f8b8-3d49-4916-b207-ef0a46453f02">
